### PR TITLE
Debos recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ following actions:
   A corresponding command to decompress the overly is added `*.postinst`
 - `extra` action: add extra file
 - `downloads` action: add extra packages
+- `debos` action: [only in debos mode] add pre- and post-action to debos recipe
+  output
 
 Some of the actions support substitutions using
 [jinja](https://palletsprojects.com/p/jinja/) notation, making it easier to

--- a/simple_cdd_yaml/actions.py
+++ b/simple_cdd_yaml/actions.py
@@ -6,6 +6,7 @@ import tarfile
 import re
 import shutil
 import textwrap
+import uuid
 import jinja2
 from simple_cdd_yaml.yaml_tools import load_yaml
 
@@ -24,6 +25,21 @@ OVERLAY_TEMPLATE_STR = \
 tar -xf ${SCDD_EXTRAS}/{{overlay}} -C {{destination}}
 
 """
+
+SCRIPT_TEMPLATE_DICT = \
+    {
+         'action': 'run',
+         'description': 'Script action',
+         'script': 'scripts/script.sh'
+    }
+
+COMMAND_TEMPLATE_DICT = \
+    {
+         'action': 'run',
+         'description': 'Command action',
+         'chroot': False,
+         'command': ''
+    }
 
 
 class ActionError(Exception):
@@ -53,7 +69,13 @@ class Action:
         self.output_dir = pl.Path(args_dict['output'])
         self.debos = args_dict['debos']
         self.debos_output_dir = pl.Path(args_dict['debos_output']) / self.profile
-        self.result = []
+        self.result = {
+            'architecture': '',
+            'chroot_default': False,
+            'actions': [], 
+            'pre-actions': [], 
+            'post-actions': [],
+        }
 
     @staticmethod
     def _print(text, header=None, width=68):
@@ -100,28 +122,62 @@ class Action:
         with open(output_file, mode='a', encoding='utf-8') as file:
             file.write(string)
 
-    def _perform_action(self, props):
+    def perform_action(self, props):
         """ Perform the action specific tasks and return result """
+        raise NotImplementedError('Action is an abstract base class!')
+
+    def perform_debos_action(self, props):
+        """ Process debos action specific tasks and return result """
         raise NotImplementedError('Action is an abstract base class!')
 
     def execute(self, props):
         """ Execute an action """
         self._action_inform(props)
-        result = self._perform_action(props)
+        if self.debos:
+            result = self.perform_debos_action(props)
+        else:
+            result = self.perform_action(props)
         if result:
             if not self.action_out:
                 self.action_out = props['action']
             self._write_action(result, self.action_out)
 
-    def append_result(self, new_result: dict):
+    def append_result(self, new_result: dict, key='actions'):
         """ Append a new result to the result list """
         added_result = copy.deepcopy(new_result)
-        self.result.append(added_result)
+        self.result[key].append(added_result)
+
+    def extend_result(self, new_result: dict, key='actions'):
+        """ Append a new result to the result list """
+        added_result = copy.deepcopy(new_result)
+        self.result[key].extend(added_result)
+
+    def prepend_result(self, new_result: dict, key='actions'):
+        """ Prepend a new result to the result list """
+        added_result = copy.deepcopy(new_result)
+        self.result[key].insert(0, added_result)
+
+    def combine_results(self, result):
+        """ Combine two result sets """
+        for key in ('actions', 'pre-actions', 'post-actions'):
+            self.result[key].extend(result[key])
+        for option in ('architecture', 'chroot_default'):
+            if result.get(option):
+                self.result[option] = result[option]
+
+    def unique_filename(self, base='script', ext='sh', description=None):
+        """ Create a name from description or using uuid """
+        name = base + '_'
+        if description:
+            name += description.lower()
+        else:
+            name += str(uuid.uuid4().hex)
+        return "".join([x if x.isalnum() else "_" for x in name]) + '.' + ext
 
 
 class ConfAction(Action):
     """ Conf action """
-    def _perform_action(self, props):
+    def perform_action(self, props):
         description = props.get('description', 'Conf settings')
         conf_str = f'# {description}\n'
         if variables := props.get('variables'):
@@ -132,13 +188,20 @@ class ConfAction(Action):
                 conf_str += f'export {var}="{value}"\n'
         if variables or env_variables:
             return conf_str
+        return None
+
+    def perform_debos_action(self, props):
+        return None
 
 
 class PreseedAction(Action):
     """ Preseed action """
-    def _perform_action(self, props):
+    def perform_action(self, props):
         return self._read_substitute(props['preconf'],
                                      props.get('substitutions', {}))
+
+    def perform_debos_action(self, props):
+        return None
 
 
 class AptAction(Action):
@@ -150,16 +213,13 @@ class AptAction(Action):
         self.packages_template = jinja2.Template(PACKAGES_TEMPLATE_STR)
         self.all_pkgs = set()
 
-    def _perform_action(self, props):
+    def perform_action(self, props):
         """ Process APT action """
-        scripted = props.get('scripted', False)
         if packages := props.get('packages'):
             pkg_list = ' '.join(packages)
             self._print(pkg_list, header='Requested packages:')
             description = props.get('description', 'Install packages')
-            if self.debos:
-                self.append_result(props)
-            if scripted:
+            if props.get('scripted', False):
                 apt_install_script = self.packages_template.render(
                     description=description,
                     pkg_list=pkg_list)
@@ -167,6 +227,11 @@ class AptAction(Action):
                 return None
             packages.insert(0, '# ' + description)
             return '\n'.join(packages) + '\n\n'
+        return None
+
+    def perform_debos_action(self, props):
+        self.append_result(props)
+
 
 
 class OverlayAction(Action):
@@ -175,8 +240,8 @@ class OverlayAction(Action):
         super().__init__(args)
         self.overlay_template = jinja2.Template(OVERLAY_TEMPLATE_STR)
 
-    def _perform_action(self, props):
-        description = props.get('description', 'Overlay')
+    def compress_overlay(self, props, output_dir):
+        """ Compress overlay into tarball """
         user = props.get('user')
         overlay_name = props['source'].replace('/', '.')
         source_dir = pl.PurePath(self.input_dir / props['source'])
@@ -189,31 +254,36 @@ class OverlayAction(Action):
             if user == 'root':
                 destination = '/root/'
         filename = f'{self.profile}.{overlay_name}.tar.gz'
-        output_file = self.output_dir / 'extra' / filename
+        output_file = output_dir / filename
         with tarfile.open(output_file, "w:gz") as tar:
             tar.add(source_dir, arcname='', filter=tar_filter)
+        return filename, destination
+
+    def perform_action(self, props):
+        output_dir = self.output_dir / 'extra'
+        filename, destination = self.compress_overlay(props, output_dir)
+        self._write_action(f'extra/{filename}\n', extension='extra',
+                           no_duplicate=True)
         extract_commands = self.overlay_template.render(
-            description=description,
+            description=props.get('description', 'Overlay'),
             overlay=filename,
             destination=destination,
         )
-        self._write_action(f'extra/{filename}\n', extension='extra',
-                           no_duplicate=True)
         self._write_action(extract_commands, extension='postinst')
+
+    def perform_debos_action(self, props):
+        output_dir = self.debos_output_dir / 'overlays'
+        filename, destination = self.compress_overlay(props, output_dir)
+        debos_action = dict(COMMAND_TEMPLATE_DICT,
+            description=props.get('description', 'Overlay'),
+            command=f'tar -xf $ARTIFACTDIR/overlays/{filename} -C {destination}'
+        )
+        self.append_result(debos_action)
 
 
 class RunAction(Action):
     """ Run action """
     action_out = 'postinst'
-
-    def _perform_action(self, props):
-        if all(x in props for x in ['script', 'command']):
-            raise ActionError('Too many keywords: script and command found!')
-        if 'script' in props:
-            return self.script(props)
-        if 'command' in props:
-            return self.command(props)
-        raise ActionError('Missing script or command keyword!')
 
     def script(self, props):
         """ Shell commands to run a script """
@@ -232,10 +302,35 @@ class RunAction(Action):
             command = f"su - {user} << 'EOF'\n{command}\nEOF"
         return f'\n# {description}\n{command}\n'
 
+    def create_run_script(self, props):
+        """ Create script from run action """
+        if all(x in props for x in ['script', 'command']):
+            raise ActionError('Too many keywords: script and command found!')
+        if 'script' in props:
+            return self.script(props)
+        if 'command' in props:
+            return self.command(props)
+        raise ActionError('Missing script or command keyword!')
+
+    def perform_action(self, props):
+        return self.create_run_script(props)
+
+    def perform_debos_action(self, props):
+        script_str = '#!/bin/sh' + self.create_run_script(props)
+        filename = self.unique_filename(description=props.get('description'))
+        output_file = self.debos_output_dir / 'scripts' / filename
+        with open(output_file, mode='w', encoding='utf-8') as file:
+            file.write(script_str)
+        debos_action = dict(SCRIPT_TEMPLATE_DICT,
+            description=props.get('description', 'Script'),
+            script='scripts/'+filename,
+        )
+        self.append_result(debos_action)
+
 
 class ExtraAction(Action):
     """ Extra action """
-    def _perform_action(self, props):
+    def perform_action(self, props):
         description = props.get('description', 'Extra files')
         self._write_action(f'# {description}\n', extension='extra')
         extra_files = []
@@ -247,21 +342,58 @@ class ExtraAction(Action):
         self._print(' '.join(extra_files), header='Extra files:')
         return '\n'.join(extra_files) + '\n'
 
+    def perform_debos_action(self, props):
+        return None
+
 
 class DownloadsAction(Action):
     """ Downloads action """
-    def _perform_action(self, props):
+    def perform_action(self, props):
         description = props.get('description', 'Additional packages')
         pkg_list = props['packages']
         self._print(' '.join(pkg_list), header='Extra packages:')
         downloads_pkg_list = '\n'.join(pkg_list)
         return f'# {description}\n{downloads_pkg_list}\n'
 
+    def perform_debos_action(self, props):
+        return None
 
 class DebosAction(Action):
     """ Debos action """
-    def _perform_action(self, props):
+    def __init__(self, args_dict):
+        super().__init__(args_dict)
+        self.args_dict = args_dict
+        self.actions = {
+            'overlay': OverlayAction,
+            'run': RunAction,
+        }
+
+    def create_action(self, action_type, args):
+        """ Create a new action """
+        try:
+            return self.actions[action_type](args)
+        except KeyError:
+            return None
+
+    def process_actions(self, action_list, action_key):
+        """ Process given list of actions """
+        for action_props in action_list:
+            action_type = action_props['action']
+            action = self.create_action(action_type, self.args_dict)
+            if action:
+                action.execute(action_props)
+                self.extend_result(action.result['actions'], key=action_key)
+            else:
+                self.append_result(action_props, key=action_key)
+
+    def perform_action(self, props):
         return None
+
+    def perform_debos_action(self, props):
+        for option in ('architecture', 'chroot_default'):
+            self.result[option] = props[option]    
+        for debos_action_type in ('pre-actions', 'post-actions'):
+            self.process_actions(props[debos_action_type], debos_action_type)
 
 
 class RecipeAction(Action):
@@ -305,7 +437,7 @@ class RecipeAction(Action):
             return dict(self.args_dict, input=working_dir)
         return dict(self.args_dict)
 
-    def _perform_action(self, props):
+    def process_actions(self, props):
         """ Perform all actions contained in the recipe """
         self._working_dir(props)
         recipe_filename =  props['recipe']
@@ -316,7 +448,13 @@ class RecipeAction(Action):
             action_type = action_props['action']
             action = self.create_action(action_type, args_dict)
             action.execute(action_props)
-            self.result.extend(action.result)
+            self.combine_results(action.result)
+
+    def perform_debos_action(self, props):
+        self.process_actions(props)
+
+    def perform_action(self, props):
+        self.process_actions(props)
 
     def get_result(self):
         """ Return results dictionary """

--- a/simple_cdd_yaml/actions.py
+++ b/simple_cdd_yaml/actions.py
@@ -276,7 +276,7 @@ class OverlayAction(Action):
         filename, destination = self.compress_overlay(props, output_dir)
         debos_action = dict(COMMAND_TEMPLATE_DICT,
             description=props.get('description', 'Overlay'),
-            command=f'tar -xf $ARTIFACTDIR/overlays/{filename} -C {destination}'
+            command=f'tar -xf $ARTIFACTDIR/overlays/{filename} -C $ROOTDIR{destination}'
         )
         self.append_result(debos_action)
 

--- a/simple_cdd_yaml/recipe_interpreter.py
+++ b/simple_cdd_yaml/recipe_interpreter.py
@@ -32,6 +32,7 @@ class YamlRecipeInterpreter():
         self.profile = self.find_profile_name(args)
         self.output_dir = pl.Path(args.output)
         self.postinst_template = jinja2.Template(POSTINST_TEMPLATE_STR)
+        self.debos = args.debos
         self.debos_output_dir = pl.Path(args.debos_output) / self.profile
         self.recipe_action = actions.RecipeAction(vars(args))
 
@@ -41,7 +42,7 @@ class YamlRecipeInterpreter():
             'action': 'recipe',
             'description': f'Load {self.profile} recipe',
             'recipe': self.recipe_file,
-            'substitutions': None
+            'substitutions': {'debos': self.debos}
         }
 
     def find_profile_name(self, args):

--- a/simple_cdd_yaml/simple_cdd_yaml.py
+++ b/simple_cdd_yaml/simple_cdd_yaml.py
@@ -17,9 +17,16 @@ def main():
                         help='Profile output directory')
     parser.add_argument('--input', type=str, default='.',
                         help='Recipe/action working directory')
+    parser.add_argument('--debos', type=bool, default=False,
+                        help='Whether or not to generate a debos recipe')
+    parser.add_argument('--debos-output', type=str, default='./debos',
+                        help='Debos recipe output directory')
     try:
         arguments = parser.parse_args()
-        interp.YamlRecipeInterpreter(arguments).generate_profile()
+        if arguments.debos:
+            interp.YamlRecipeInterpreter(arguments).generate_debos_recipe()
+        else:
+            interp.YamlRecipeInterpreter(arguments).generate_profile()
     except KeyboardInterrupt:
         pass
 

--- a/simple_cdd_yaml/simple_cdd_yaml.py
+++ b/simple_cdd_yaml/simple_cdd_yaml.py
@@ -17,8 +17,8 @@ def main():
                         help='Profile output directory')
     parser.add_argument('--input', type=str, default='.',
                         help='Recipe/action working directory')
-    parser.add_argument('--debos', type=bool, default=False,
-                        help='Whether or not to generate a debos recipe')
+    parser.add_argument('--debos', default=False, action='store_true',
+                        help='If provided, try to generate a debos recipe')
     parser.add_argument('--debos-output', type=str, default='./debos',
                         help='Debos recipe output directory')
     try:

--- a/simple_cdd_yaml/yaml_tools.py
+++ b/simple_cdd_yaml/yaml_tools.py
@@ -20,7 +20,24 @@ def load_yaml(file, substitutions=None):
     return yaml.safe_load(rendered)
 
 
+class LevelWhiteLineDumper(yaml.SafeDumper):
+    """ Adds white lines on below a given yaml object level """
+    level = 1
+
+    @classmethod
+    def set_level(cls, level):
+        """ Level below which white lines are included  """
+        cls.level = level
+        return cls
+
+    def write_line_break(self, data=None):
+        super().write_line_break(data)
+        if len(self.indents) < self.level + 1:
+            super().write_line_break()
+
+
 def save_yaml(filepath, yaml_dict):
     """ Store dictionary as yaml file """
     with open(filepath, mode='w+', encoding="utf-8") as file:
-        yaml.dump(yaml_dict, file, allow_unicode=True)
+        yaml.dump(yaml_dict, file, Dumper=LevelWhiteLineDumper.set_level(2),
+                  allow_unicode=True, width=4096, sort_keys=False)

--- a/simple_cdd_yaml/yaml_tools.py
+++ b/simple_cdd_yaml/yaml_tools.py
@@ -18,3 +18,9 @@ def load_yaml(file, substitutions=None):
         template = jinja2.Template(data.read(), undefined=NullUndefined)
     rendered = template.render(substitutions)
     return yaml.safe_load(rendered)
+
+
+def save_yaml(filepath, yaml_dict):
+    """ Store dictionary as yaml file """
+    with open(filepath, mode='w+', encoding="utf-8") as file:
+        yaml.dump(yaml_dict, file, allow_unicode=True)


### PR DESCRIPTION
Include support to generate Debos recipes

- Activated when the debos options is chosen
- Introduces a new debos action to add pre-actions (put at the beginning of the debos recipe) and post-actions (put at the end of the final debos recipe) and include some custom options (architecture and chroot_default)
- Also introduces the options to export the recipe (and its accompanying scripts and overlays) into a custom directory