### PR TITLE
Remove the `dist` input argument

### DIFF
--- a/simple_cdd_yaml/simple_cdd_yaml.py
+++ b/simple_cdd_yaml/simple_cdd_yaml.py
@@ -11,8 +11,6 @@ def main():
                         help='set the config yaml file')
     parser.add_argument('--profile', type=str, default=None,
                         help='profile name')
-    parser.add_argument('--dist', type=str, default='bullseye',
-                        help='Debian distribution (default: bullseye)')
     parser.add_argument('--output', type=str, default='.',
                         help='Profile output directory')
     parser.add_argument('--input', type=str, default='.',


### PR DESCRIPTION
This is not a special input argument and there's no reason to have it as input argument.

Fixes #3 